### PR TITLE
#3590 log uri to full report when running aggregate goal

### DIFF
--- a/serenity-maven-plugin/src/main/java/net/serenitybdd/maven/plugins/SerenityAggregatorMojo.java
+++ b/serenity-maven-plugin/src/main/java/net/serenitybdd/maven/plugins/SerenityAggregatorMojo.java
@@ -289,6 +289,9 @@ public class SerenityAggregatorMojo extends AbstractMojo {
         getReporter().setTags(tags);
         getReporter().setGenerateTestOutcomeReports();
         getReporter().generateReportsForTestResultsFrom(sourceDirectory);
+
+        Path index = outputDirectory.toPath().resolve("index.html");
+        LOGGER.info("  - Full Report: {}",  index.toUri());
     }
 
     private void generateExtraReports() {


### PR DESCRIPTION
#### Summary of this PR
This pull request addresses Issue #3590 by including a logger.info statement that outputs the URI of the full report.
#### Intended effect
Users can now see the URI to the full Serenity report in the console output when running acceptance tests with Maven. This enhancement improves user experience by making it easier to locate the full report.
#### How should this be manually tested?
- Clone the Serenity Cucumber Starter project from [here](https://github.com/serenity-bdd/serenity-cucumber-starter).
- Update the serenity version `<version>4.2.10-SNAPSHOT</version>`
- Run the acceptance tests using Maven: mvn clean verify.
- Verify that the console output includes a log message with the URI to the full Serenity report
#### Side effects
No known side effects. The change is scoped to the logger.info output and only triggered when serenity.generateFullReport is undefined or explicitly set to true.
#### Documentation
No updates to the documentation are required unless desired to highlight this feature.
#### Relevant tickets
 - [Issue #3590](https://github.com/serenity-bdd/serenity-core/issues/3590)

